### PR TITLE
`devel`→`main`: add missed commit for v0.6.1

### DIFF
--- a/bin/sailfishos-chum-gui-installer
+++ b/bin/sailfishos-chum-gui-installer
@@ -54,14 +54,15 @@ logfile="$2"
 umask 113
 [ "$PWD" = / ] || cd /  # Set PWD to /, if not already
 
-# Prefix first output with a linebreak, dashes and another linebreak, if logfile size > 0
+# Prefix first output with a line of underscores and an empty line, if logfile size > 0
+linebreaks=""
 if [ -s "$logfile" ]
-then printf '\n%s\n\n' "-----------------------------"
+then linebreaks='_____________________________\n\n'
 fi
 
 # Write first entry to logfile:
 logentry="[Info] PID $mypid is logging to $logfile on"
-if printf '%s %s\n' "$logentry" "$(date -Iseconds)"
+if printf "${linebreaks}%s\n" "$logentry $(date -Iseconds)"
 then systemd-cat -t "$called" -p 6 printf '%s\n' "$logentry"
 else systemd-cat -t "$called" -p 4 printf '%s\n' "[Warning] PID $mypid failed to write to $logfile"
 fi

--- a/rpm/sailfishos-chum-gui-installer.spec
+++ b/rpm/sailfishos-chum-gui-installer.spec
@@ -6,7 +6,7 @@ Name:           sailfishos-chum-gui-installer
 # natural number greater or equal to 1, which may be prefixed with one of
 # {alpha,beta,rc,release} (e.g., "beta3").  For details and reasons, see
 # https://github.com/storeman-developers/harbour-storeman-installer/wiki/Git-tag-format
-Version:        0.6.1
+Version:        0.6.2
 Release:        1
 Group:          Applications/System
 URL:            https://github.com/sailfishos-chum/%{name}

--- a/rpm/sailfishos-chum-gui-installer.spec
+++ b/rpm/sailfishos-chum-gui-installer.spec
@@ -6,7 +6,7 @@ Name:           sailfishos-chum-gui-installer
 # natural number greater or equal to 1, which may be prefixed with one of
 # {alpha,beta,rc,release} (e.g., "beta3").  For details and reasons, see
 # https://github.com/storeman-developers/harbour-storeman-installer/wiki/Git-tag-format
-Version:        0.6.2
+Version:        0.6.1
 Release:        1
 Group:          Applications/System
 URL:            https://github.com/sailfishos-chum/%{name}


### PR DESCRIPTION
Corresponds to https://github.com/storeman-developers/harbour-storeman-installer/commit/b5c7164f4a1ec5a7bce1bd949baaa538a9a7c1ac